### PR TITLE
Update oclint.yml

### DIFF
--- a/fastlane/assets/oclint.yml
+++ b/fastlane/assets/oclint.yml
@@ -3,7 +3,6 @@ rules:
 - CollapsibleIfStatements
 - ConstantConditionalOperator
 - DeadCode
-- DoubleNegative
 - ForLoopShouldBeWhileLoop
 - JumbledIncrementer
 - MisplacedNullCheck


### PR DESCRIPTION
Удалено правило, запрещающее двойное отрицание.